### PR TITLE
Nihdev 150 add api auth to user templates

### DIFF
--- a/src/user_templates_api/templates/jupyter_lab/api_tutorial/render.py
+++ b/src/user_templates_api/templates/jupyter_lab/api_tutorial/render.py
@@ -5,9 +5,7 @@ import re
 
 from django.conf import settings
 
-from user_templates_api.utils.client import get_client
-
-def render(body):
+def render(body, util_client):
     uuids = body['uuids']
     entity_type = body['entity_type']
 
@@ -21,7 +19,7 @@ def render(body):
             + settings.CONFIG['PORTAL_INDEX_PATH'])
         cells += _get_cells('files.txt', search_url=search_url)
 
-    uuids_to_files = get_client().get_files(uuids)
+    uuids_to_files = util_client.get_files(uuids)
     uuids_to_zarr_files = _limit_to_zarr_files(uuids_to_files)
     zarr_files = set().union(*uuids_to_zarr_files.values())
     if zarr_files:

--- a/src/user_templates_api/templates/jupyter_lab/visualization/render.py
+++ b/src/user_templates_api/templates/jupyter_lab/visualization/render.py
@@ -1,15 +1,11 @@
 import nbformat
 from nbformat.v4 import (new_notebook, new_markdown_cell, new_code_cell)
 import vitessce
-from django.conf import settings
-from user_templates_api.utils.client import get_client
-import json
 
-def render(body):
+def render(body, util_client):
     uuid = body['uuid']
-    client = get_client()
-    entity = client.get_entity(uuid)
-    vitessce_conf = client.get_vitessce_conf_cells_and_lifted_uuid(entity).vitessce_conf
+    entity = util_client.get_entity(uuid)
+    vitessce_conf = util_client.get_vitessce_conf_cells_and_lifted_uuid(entity).vitessce_conf
     if (vitessce_conf is None
             or vitessce_conf.conf is None
             or vitessce_conf.cells is None):

--- a/src/user_templates_api/utils/client.py
+++ b/src/user_templates_api/utils/client.py
@@ -11,7 +11,6 @@ from .client_utils import files_from_response
 from portal_visualization.builder_factory import get_view_config_builder
 from portal_visualization.builders.base_builders import ConfCells
 from django.conf import settings
-from django.apps import apps
 
 Entity = namedtuple('Entity', ['uuid', 'type', 'name'], defaults=['TODO: name'])
 
@@ -31,15 +30,10 @@ def _get_hits(response_json):
     inner_hits = outer_hits['hits']
     return inner_hits
 
-def get_client():
-    auth_helper = apps.get_app_config(
-        "user_templates_api"
-    ).auth_helper
-
+def get_client(group_token):
     return ApiClient(
         settings.CONFIG['ENTITY_API_BASE'],
-        # TODO: This should just be the getProcessSecret() from authHelper
-        auth_helper.getProcessSecret()
+        group_token
     )
 class ApiClient:
     def __init__(self, url_base=None, groups_token=None):


### PR DESCRIPTION
This PR adds support for using the token passed in the Auth header for instantiating the API Client. This is so that any outwards API calls use that group token (to authenticate the end user individually) rather than just using the client secret.