### PR TITLE
Thomcsmits/fix visualization template

### DIFF
--- a/src/user_templates_api/templates/jupyter_lab/templates/visualization/metadata.json
+++ b/src/user_templates_api/templates/jupyter_lab/templates/visualization/metadata.json
@@ -5,7 +5,7 @@
     "vitessce",
     "visualization"
   ],
-  "is_multi_dataset_template": false,
+  "is_multi_dataset_template": true,
   "template_format": "python",
   "is_hidden": false
 }

--- a/src/user_templates_api/templates/jupyter_lab/templates/visualization/render.py
+++ b/src/user_templates_api/templates/jupyter_lab/templates/visualization/render.py
@@ -20,7 +20,10 @@ class JupyterLabVisualizationRender(JupyterLabRender):
             or vitessce_conf.conf is None
             or vitessce_conf.cells is None
         ):
-            return {"success": False, "message": "Vitessce conf not found."}
+            vitessce_conf.cells = new_markdown_cell(
+                "## Error in visualization\n"
+                f"Vitessce visualization could not be displayed for dataset {uuid}."
+            )
 
         hubmap_id = entity["hubmap_id"]
         cells = [

--- a/src/user_templates_api/templates/jupyter_lab/templates/visualization/render.py
+++ b/src/user_templates_api/templates/jupyter_lab/templates/visualization/render.py
@@ -25,19 +25,21 @@ class JupyterLabVisualizationRender(JupyterLabRender):
                 f"Vitessce visualization could not be displayed for dataset {uuid}."
             )
 
-        hubmap_id = entity["hubmap_id"]
         cells = [
             new_markdown_cell(
-                f"Visualization for {hubmap_id}; "
-                "If this notebook is running in a HuBMAP workspace, the dataset is symlinked:"
+                "# Vitessce visualization for single dataset\n"
+                "This notebook shows a Vitessce visualization for a dataset."
             ),
-            new_code_cell(f"!ls datasets/{uuids}"),
-            new_markdown_cell("Visualization requires extra code to be installed:"),
             new_code_cell(
                 "!pip uninstall community flask albumentations -y "
                 "# Preinstalled on Colab; Causes version conflicts.\n"
                 f"!pip install vitessce[all]=={vitessce.__version__}"
             ),
+            new_markdown_cell(
+                "## Linked datasets\n"
+                "For this template, symlinking is not required. "
+                "This template only visualizes one dataset, it will automatically select the first of the datasets."
+            ),  
             *vitessce_conf.cells,
         ]
 

--- a/src/user_templates_api/templates/jupyter_lab/templates/visualization/render.py
+++ b/src/user_templates_api/templates/jupyter_lab/templates/visualization/render.py
@@ -39,7 +39,7 @@ class JupyterLabVisualizationRender(JupyterLabRender):
                 "## Linked datasets\n"
                 "For this template, symlinking is not required. "
                 "This template only visualizes one dataset, it will automatically select the first of the datasets."
-            ),  
+            ),
             *vitessce_conf.cells,
         ]
 

--- a/src/user_templates_api/templates/jupyter_lab/templates/visualization/render.py
+++ b/src/user_templates_api/templates/jupyter_lab/templates/visualization/render.py
@@ -8,9 +8,10 @@ from user_templates_api.utils.client import get_client
 class JupyterLabVisualizationRender(JupyterLabRender):
     def python_generate_template_data(self, data):
         uuids = data["body"]["uuids"]
+        uuid = uuids[0]
 
         client = get_client(data["group_token"])
-        entity = client.get_entity(uuids)
+        entity = client.get_entity(uuid)
         vitessce_conf = client.get_vitessce_conf_cells_and_lifted_uuid(
             entity
         ).vitessce_conf


### PR DESCRIPTION
- remove single-dataset requirement by selecting first dataset
- remove error return, instead return markdown cell indicating that the conf couldn't be retrieved
- add title and more descriptive text in returned template