### PR TITLE
fix: update anndata read to read_h5ad (futurewarning for deprecation)

### DIFF
--- a/src/user_templates_api/templates/jupyter_lab/templates/compress_anndata/template.txt
+++ b/src/user_templates_api/templates/jupyter_lab/templates/compress_anndata/template.txt
@@ -117,7 +117,7 @@
     "    path = data_path + uuid + '/' + file\n",
     "    if not os.path.exists(path): \n",
     "        raise FileExistsError\n",
-    "    adata_i = ad.read(path)\n",
+    "    adata_i = ad.read_h5ad(path)\n",
     "\n",
     "    ## compress anndata\n",
     "    adata_i = compress_anndata_delete(adata_i, groups)\n",


### PR DESCRIPTION
To fix this FutureWarning:

> FutureWarning: `anndata.read` is deprecated, use `anndata.read_h5ad` instead. `ad.read` will be removed in mid 2024.