### PR TITLE
Fix file retrieval outdir=datasets

### DIFF
--- a/src/user_templates_api/templates/jupyter_lab/templates/file_retrieval/template.txt
+++ b/src/user_templates_api/templates/jupyter_lab/templates/file_retrieval/template.txt
@@ -3,7 +3,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Retrieve files with the search and assets API"
+    "# Retrieve files with the search and assets API\n",
+    "This template shows how to find existing files with the search API and retrieve these files from the assets API.\n",
+    "This can be useful if the data is not symlinked or UUIDs are added to the list later."
    ]
   },
   {

--- a/src/user_templates_api/templates/jupyter_lab/templates/file_retrieval/template.txt
+++ b/src/user_templates_api/templates/jupyter_lab/templates/file_retrieval/template.txt
@@ -155,14 +155,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "retrieve_files_remote(uuids[0], uuid_to_files[uuids[0]][0], outdir='datasets')"
+    "retrieve_files_remote(uuids[0], uuid_to_files[uuids[0]][0], outdir='data')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The file is now locally saved under the datasets/_uuid_ folder.\n",
+    "The file is now locally saved under the data/_<uuid>_ folder.\n",
+    "Note that in the HuBMAP Workspaces, the 'datasets' folder is read only.\n",
     "\n",
     "We could also use this to save all files of a dataset locally. However, this takes quite some time."
    ]
@@ -175,7 +176,7 @@
    "source": [
     "# Run to download all files from this dataset.\n",
     "# for file in uuid_to_files[uuids[0]]: \n",
-    "#     retrieve_files_remote(uuids[0], file, outdir='datasets')"
+    "#     retrieve_files_remote(uuids[0], file, outdir='data')"
    ]
   }
 ]


### PR DESCRIPTION
This template is meant to retrieve files (e.g. in other environments where data is not symlinked, or to add other data) but can also be run when the datasets folder exist. Setting datasets as the output folder causes a read-only permission error. This change fixes this error, and adds some information on the template.