### PR TITLE
bump vitessce to 3.2.6 (and bump portal-visualization, zarr accordingly)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -72,5 +72,4 @@ wcwidth==0.2.6
 Werkzeug==2.2.2
 yarl==1.8.2
 zarr==2.18.0
-zict==3.0.0
 zipp==3.11.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -45,7 +45,7 @@ numpy==1.24.1
 pandas==1.5.2
 pathspec==0.10.3
 platformdirs==2.6.2
-portal-visualization @ https://github.com/hubmapconsortium/portal-visualization/archive/refs/tags/0.2.3.zip#sha256=c9210acb1ed1b58cfc18a0b5d69ab62d0f533359e3c47b782caab870e1706de7
+portal-visualization @ https://github.com/hubmapconsortium/portal-visualization/archive/refs/tags/0.2.3.zip
 property==2.2
 prov==2.0.0
 pycodestyle==2.10.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -45,7 +45,7 @@ numpy==1.24.1
 pandas==1.5.2
 pathspec==0.10.3
 platformdirs==2.6.2
-portal-visualization @ https://github.com/hubmapconsortium/portal-visualization/archive/refs/tags/0.2.0.zip
+portal-visualization @ https://github.com/hubmapconsortium/portal-visualization/archive/refs/tags/0.2.3.zip#sha256=c9210acb1ed1b58cfc18a0b5d69ab62d0f533359e3c47b782caab870e1706de7
 property==2.2
 prov==2.0.0
 pycodestyle==2.10.0
@@ -67,9 +67,10 @@ tomli==2.0.1
 traitlets==5.8.1
 typing_extensions==4.4.0
 urllib3==1.26.13
-vitessce==3.2.3
+vitessce==3.2.6
 wcwidth==0.2.6
 Werkzeug==2.2.2
 yarl==1.8.2
-zarr==2.13.3
+zarr==2.18.0
+zict==3.0.0
 zipp==3.11.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -69,5 +69,4 @@ wcwidth==0.2.6
 Werkzeug==2.2.2
 yarl==1.8.2
 zarr==2.18.0
-zict==3.0.0
 zipp==3.11.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,7 @@ numpy==1.24.1
 pandas==1.5.2
 pathspec==0.10.3
 platformdirs==2.6.2
-portal-visualization @ https://github.com/hubmapconsortium/portal-visualization/archive/refs/tags/0.2.3.zip#sha256=c9210acb1ed1b58cfc18a0b5d69ab62d0f533359e3c47b782caab870e1706de7
+portal-visualization @ https://github.com/hubmapconsortium/portal-visualization/archive/refs/tags/0.2.3.zip
 property==2.2
 prov==2.0.0
 pycparser==2.21

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,7 @@ numpy==1.24.1
 pandas==1.5.2
 pathspec==0.10.3
 platformdirs==2.6.2
-portal-visualization @ https://github.com/hubmapconsortium/portal-visualization/archive/refs/tags/0.2.0.zip
+portal-visualization @ https://github.com/hubmapconsortium/portal-visualization/archive/refs/tags/0.2.3.zip#sha256=c9210acb1ed1b58cfc18a0b5d69ab62d0f533359e3c47b782caab870e1706de7
 property==2.2
 prov==2.0.0
 pycparser==2.21
@@ -64,9 +64,10 @@ tomli==2.0.1
 traitlets==5.8.1
 typing_extensions==4.4.0
 urllib3==1.26.13
-vitessce==3.2.3
+vitessce==3.2.6
 wcwidth==0.2.6
 Werkzeug==2.2.2
 yarl==1.8.2
-zarr==2.13.3
+zarr==2.18.0
+zict==3.0.0
 zipp==3.11.0


### PR DESCRIPTION
This bumps vitessce to 3.2.6 without adding any new dependencies.