### PR TITLE
Add R tag to blank notebook

### DIFF
--- a/src/user_templates_api/templates/jupyter_lab/templates/blank_r/metadata.json
+++ b/src/user_templates_api/templates/jupyter_lab/templates/blank_r/metadata.json
@@ -1,8 +1,7 @@
 {
   "title": "Blank Notebook",
   "description": "Notebook only inserting UUIDs of added datasets",
-  "tags": [
-  ], 
+  "tags": ["R"], 
   "is_multi_dataset_template": true,
   "template_format": "jinja",
   "job_types": ["jupyter_lab_r"],


### PR DESCRIPTION
My apologies for the oversight, adding this tag will make the R changes easier in the portal-ui in the short term. We can revisit the organization of templates/environments after the hackathon.