### PR TITLE
Updates the file_retrieval notebook and example dataset to use a Visi…

### DIFF
--- a/src/user_templates_api/templates/jupyter_lab/templates/file_retrieval/README.md
+++ b/src/user_templates_api/templates/jupyter_lab/templates/file_retrieval/README.md
@@ -1,0 +1,2 @@
+Notebook that shows how to find existing files with the search API and retrieve these files from the assets API. This is useful if the data was not symlinked prior to launching the workspace. 
+Works with: any HuBMAP processed dataset

--- a/src/user_templates_api/templates/jupyter_lab/templates/file_retrieval/metadata.json
+++ b/src/user_templates_api/templates/jupyter_lab/templates/file_retrieval/metadata.json
@@ -9,11 +9,11 @@
   "template_format": "jinja",
   "examples": [
     {
-      "title": "Retrieve a full dataset",
-      "description": "Use the assets API to retrieve a full seqFISH dataset.",
-      "datasets": ["c6a254b2dc2ed46b002500ade163a7cc"]
+      "title": "Retrieve files from a HuBMAP processed dataset",
+      "description": "Use the assets API to retrieve files from a Visium (no probes) [Salmon + Scanpy] dataset.",
+      "datasets": ["8fd6bb5cd1a69fc699342eb118565734"]
     }
   ],
   "is_hidden": false,
-  "last_modified_unix_timestamp": 1723749414
+  "last_modified_unix_timestamp": 1733256667
 }

--- a/src/user_templates_api/templates/jupyter_lab/templates/file_retrieval/template.txt
+++ b/src/user_templates_api/templates/jupyter_lab/templates/file_retrieval/template.txt
@@ -95,7 +95,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Before we can use this, we need to know what files a dataset has. We can see this on the [HuBMAP Data Portal website](https://portal.hubmapconsortium.org), but we can also retrieve this directly through the search API, as shown below."
+    "Before we can use this, we need to know what files a dataset has. We can see a listing of processing output files on the [HuBMAP Data Portal website](https://portal.hubmapconsortium.org) or retrieve this directly through the search API, as shown below."
    ]
   },
   {
@@ -179,6 +179,24 @@
     "# Run to download all files from this dataset.\n",
     "# for file in uuid_to_files[uuids[0]]: \n",
     "#     retrieve_files_remote(uuids[0], file, outdir='data')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Metadata for published processed datasets is also available in json format and can be retrieved as shown."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Run to download metadata.json files from linked datasets.\n",
+    "# for dataset in uuids: \n",
+    "#     retrieve_files_remote(dataset, 'metadata.json', outdir='data')"
    ]
   }
 ]


### PR DESCRIPTION
Updates the file_retrieval notebook and example dataset to use a Visium (no probes) processed dataset. This replaces the previously referenced seqFISH dataset for which no files listing is available from the search API.

[CAT-1066]

[CAT-1066]: https://hms-dbmi.atlassian.net/browse/CAT-1066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ