### PR TITLE
Vitessce visualization template bug fix

### DIFF
--- a/src/user_templates_api/templates/jupyter_lab/templates/visualization/render.py
+++ b/src/user_templates_api/templates/jupyter_lab/templates/visualization/render.py
@@ -7,8 +7,16 @@ from user_templates_api.utils.client import get_client
 
 class JupyterLabVisualizationRender(JupyterLabRender):
     def python_generate_template_data(self, data):
-        uuids = data["uuids"]
-        uuid = uuids[0]
+        uuids = data.get("uuids", [])
+        uuid = uuids[0] if uuids else None
+
+        if uuid is None:
+            return [
+                new_markdown_cell(
+                    "## Error in visualization\n"
+                    "No valid dataset UUID provided. Please ensure a dataset has been selected."
+                )
+            ]
 
         client = get_client(data["group_token"])
         entity = client.get_entity(uuid)


### PR DESCRIPTION
Resolves bug causing workspace creation to fail without a useful message when no datasets are selected and the Vitessce visualization template is selected. 

<img width="1432" alt="Screenshot 2025-02-03 at 4 52 34 PM" src="https://github.com/user-attachments/assets/842c1fe0-e254-4b5b-aa04-5d39ad6cea58" />
