### PR TITLE
change vitessce template to use portal_visualization as package

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -45,7 +45,6 @@ numpy==1.24.1
 pandas==1.5.2
 pathspec==0.10.3
 platformdirs==2.6.2
-portal-visualization @ https://github.com/hubmapconsortium/portal-visualization/archive/refs/tags/0.2.3.zip
 property==2.2
 prov==2.0.0
 pycodestyle==2.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,6 @@ numpy==1.24.1
 pandas==1.5.2
 pathspec==0.10.3
 platformdirs==2.6.2
-portal-visualization @ https://github.com/hubmapconsortium/portal-visualization/archive/refs/tags/0.2.6.zip
 property==2.2
 prov==2.0.0
 pycparser==2.21

--- a/src/user_templates_api/templates/jupyter_lab/templates/visualization/metadata.json
+++ b/src/user_templates_api/templates/jupyter_lab/templates/visualization/metadata.json
@@ -6,7 +6,7 @@
     "visualization"
   ],
   "is_multi_dataset_template": true,
-  "template_format": "python",
+  "template_format": "jinja",
   "examples": [
     {
       "title": "Slide-seq in Vitessce",

--- a/src/user_templates_api/templates/jupyter_lab/templates/visualization/render.py
+++ b/src/user_templates_api/templates/jupyter_lab/templates/visualization/render.py
@@ -1,64 +1,6 @@
-from importlib_metadata import version
-from nbformat.v4 import new_code_cell, new_markdown_cell
-
 from user_templates_api.templates.jupyter_lab.render import JupyterLabRender
-from user_templates_api.utils.client import get_client
 
 
-class JupyterLabVisualizationRender(JupyterLabRender):
-    def python_generate_template_data(self, data):
-        uuids = data.get("uuids", [])
-        uuid = uuids[0] if uuids else None
-
-        if uuid is None:
-            return [
-                new_markdown_cell(
-                    "## Error in visualization\n"
-                    "No valid dataset UUID provided. Please ensure a dataset has been selected."
-                )
-            ]
-
-        client = get_client(data["group_token"])
-        entity = client.get_entity(uuid)
-        vitessce_conf = client.get_vitessce_conf_cells_and_lifted_uuid(
-            entity
-        ).vitessce_conf
-
-        if not vitessce_conf or not vitessce_conf.conf or not vitessce_conf.cells:
-            return [
-                new_markdown_cell(
-                    "## Error in visualization\n"
-                    f"Vitessce visualization could not be displayed for dataset {uuid}."
-                )
-            ]
-
-        cells = [
-            new_markdown_cell(
-                "# Vitessce visualization for single dataset\n"
-                "This notebook shows a Vitessce visualization for a dataset."
-            ),
-            new_code_cell(f"!pip install vitessce[all]=={version('vitessce')}"),
-            new_markdown_cell(
-                "## Linked datasets\n"
-                "For this template, symlinking is not required. "
-                "This template only visualizes one dataset, it will automatically select the first of the datasets."
-            ),
-            *vitessce_conf.cells,
-            new_code_cell(
-                "## If you get a JavaScript error when running the above cell, it is likely due \n"
-                "## to Anywidget needing to be installed before the workspace is launched.\n"
-                "\n"
-                "## Check that anywidget is installed\n"
-                "## Uncomment the following line:\n"
-                "# import anywidget \n"
-                "\n"
-                "## If it is not yet installed:\n"
-                "# !pip install anywidget\n"
-                "\n"
-                "## Once you have checked that it is installed, close this window.\n"
-                "## In the Workspace overview page, stop all jobs.\n"
-                "## Then, launch the Workspace again."
-            ),
-        ]
-
-        return cells
+class JupyterLabExampleJinjaRender(JupyterLabRender):
+    def __init__(self):
+        pass

--- a/src/user_templates_api/templates/jupyter_lab/templates/visualization/template.txt
+++ b/src/user_templates_api/templates/jupyter_lab/templates/visualization/template.txt
@@ -1,14 +1,149 @@
-{
- "cells": [
+[
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This file is not used for creation of the visualization template."
+    "# Vitessce visualization for single dataset\n",
+    "This notebook shows a Vitessce visualization for a dataset."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For this template, symlinking is not required, as the data is fetched from the remote repository.\n",
+    "This template only visualizes one dataset, it will automatically select the first of the datasets.\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install https://github.com/hubmapconsortium/portal-visualization/archive/refs/tags/0.4.1.zip\n",
+    "!pip install vitessce anywidget uvicorn starlette"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "from portal_visualization.client import ApiClient\n",
+    "from vitessce import VitessceConfig"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## linked datasets\n",
+    "uuids = ['9358adf4674413a0e2ef1a970b66714e']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client = ApiClient(\n",
+    "    elasticsearch_endpoint='https://search.api.hubmapconsortium.org',\n",
+    "    portal_index_path=f'/v3/portal/search',\n",
+    "    assets_endpoint='https://assets.hubmapconsortium.org',\n",
+    "    soft_assay_endpoint='https://ingest.api.hubmapconsortium.org',\n",
+    "    soft_assay_endpoint_path='assaytype',\n",
+    "    entity_api_endpoint='https://entity.api.hubmapconsortium.org',\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "uuid = uuids[0]\n",
+    "entity = client.get_entity(uuid)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_image_parent(entity):\n",
+    "    ancestors = entity.get('immediate_ancestor_ids')\n",
+    "    if len(ancestors) > 0:\n",
+    "        parent = ancestors[0]\n",
+    "        parent_entity = client.get_entity(parent)\n",
+    "        if parent_entity.get('entity_type') == 'Dataset':\n",
+    "            return parent\n",
+    "    return None\n",
+    "\n",
+    "parent = None\n",
+    "if 'Image Pyramid' in entity.get('assay_display_name'):\n",
+    "    parent = get_image_parent(entity)\n",
+    "# test this later\n",
+    "epic_uuid = None\n",
+    "if 'segmentation_mask' in entity.get('vitessce-hints') and entity.get(\n",
+    "        'status') != 'Error':\n",
+    "    if parent is None:\n",
+    "        get_image_parent(entity)\n",
+    "    if 'epic' in entity.get('vitessce-hints'):\n",
+    "        epic_uuid = uuid\n",
+    "\n",
+    "vitessce_conf = client.get_vitessce_conf_cells_and_lifted_uuid(\n",
+    "    entity,\n",
+    "    parent=parent,\n",
+    "    epic_uuid=epic_uuid,\n",
+    ").vitessce_conf"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vitessce_conf.conf"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "conf = VitessceConfig.from_dict(vitessce_conf.conf)\n",
+    "conf.widget()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## If you get a JavaScript error when running the above cell, it is likely due \n",
+    "## to Anywidget needing to be installed before the workspace is launched.\n",
+    "\n",
+    "## Check that anywidget is installed\n",
+    "## Uncomment the following line:\n",
+    "# import anywidget \n",
+    "\n",
+    "## If it is not yet installed:\n",
+    "# !pip install anywidget\n",
+    "\n",
+    "## Once you have checked that it is installed, close this window.\n",
+    "## In the Workspace overview page, stop all jobs.\n",
+    "## Then, launch the Workspace again."
    ]
   }
- ],
- "metadata": {},
- "nbformat": 4,
- "nbformat_minor": 5
-}
+ ]


### PR DESCRIPTION
This PR aims to remove the separate logic for creating a vitessce config in the user-templates-api, and instead use the portal-visualization as a package in the template itself. 