### PR TITLE
fix scellop template and add metadata example

### DIFF
--- a/src/user_templates_api/templates/jupyter_lab/templates/scalable_cell_populations/metadata.json
+++ b/src/user_templates_api/templates/jupyter_lab/templates/scalable_cell_populations/metadata.json
@@ -1,6 +1,6 @@
 {
   "title": "Scalable Cell Population Explorer",
-  "description": "This notebook shows how to load the scalable cell population viewer CellPop. It loads in datasets with annotated cell types and shows these in an interactive visualization.",
+  "description": "This notebook shows how to load the scalable cell population viewer scellop. It loads in datasets with annotated cell types and shows these in an interactive visualization.",
   "tags": [
     "visualization"
   ], 
@@ -14,5 +14,5 @@
     }
   ],
   "is_hidden": false,
-  "last_modified_unix_timestamp": 1729805397
+  "last_modified_unix_timestamp": 1767696252
 }

--- a/src/user_templates_api/templates/jupyter_lab/templates/scalable_cell_populations/template.ipynb
+++ b/src/user_templates_api/templates/jupyter_lab/templates/scalable_cell_populations/template.ipynb
@@ -73,8 +73,8 @@
         "\n",
         "anndata_locations_list = [f\"./datasets/{uuid}/secondary_analysis.h5ad\" for uuid in uuids]\n",
         "\n",
-        "df = scellop.load_data_multiple(anndata_locations_list, hubmap_ids, \"predicted_CLID\")\n",
-        "scellop.ScellopWidget(df=df)"
+        "scd = scellop.load_data_multiple(anndata_locations_list, hubmap_ids, \"predicted_CLID\")\n",
+        "scellop.ScellopWidget(data=scd)"
       ]
     },
     {

--- a/src/user_templates_api/templates/jupyter_lab/templates/scalable_cell_populations/template.ipynb
+++ b/src/user_templates_api/templates/jupyter_lab/templates/scalable_cell_populations/template.ipynb
@@ -5,9 +5,7 @@
       "metadata": {},
       "source": [
         "# Scalable Cell Population Viewer\n",
-        "This notebook shows how to load the scalable cell population viewer scellop. It loads in datasets with annotated cell types and shows these in an interactive visualization.\n",
-        "\n",
-        "> This work is under active development and will be subject to change.\n",
+        "This notebook shows how to load the scalable cell population viewer _scellop_. It loads in datasets with annotated cell types and shows these in an interactive visualization.\n",
         "\n",
         "The source code can be found [here](https://github.com/hms-dbmi/scellop). Feel free to submit issues and feature requests [here](https://github.com/hms-dbmi/scellop/issues). "
       ]
@@ -18,7 +16,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "!pip install scellop==1.0.0\n",
+        "!pip install scellop==1.1.0\n",
         "!pip install hubmap-template-helper"
       ]
     },
@@ -49,10 +47,33 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "# # For now, this tool has only been tested with datasets from the assays listed below. Other assays may not yet work. \n",
-        "# # If you only want to work with known good assays, uncomment this cell.\n",
-        "# accepted_assay_display_names=[\"snRNAseq [Salmon]\", \"snRNAseq (SNARE-seq2) [Salmon]\", \"Slide-seq [Salmon]\"]\n",
-        "# uuids = hth_comp.check_template_compatibility(uuids, accepted_assay_display_names=accepted_assay_display_names)"
+        "# This tool has been tested with datasets from the assays listed below. Other assays could potentially also work. \n",
+        "accepted_assay_display_names=[\"snRNAseq [Salmon]\", \"snRNAseq (SNARE-seq2) [Salmon]\", \"Slide-seq [Salmon]\", \"snRNAseq (10x Genomics) [Salmon]\"]\n",
+        "uuids = hth_comp.check_template_compatibility(uuids, accepted_assay_display_names=accepted_assay_display_names)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# we can get some metadata about these datasets\n",
+        "import requests\n",
+        "import json\n",
+        "\n",
+        "search_api = \"https://search.api.hubmapconsortium.org/v3/portal/search\"\n",
+        "hits = json.loads(requests.post(search_api,json={\"size\": 10000, \"query\": {\"ids\": {\"values\": uuids}}, \"_source\": [\"hubmap_id\", \"title\", \"assay_display_name\", \"donor.mapped_metadata\"],},).text)[\"hits\"][\"hits\"]\n",
+        "first = lambda x: (x or [None])[0]\n",
+        "dmm_keys = [\"age_value\",\"sex\",\"height_value\",\"weight_value\",\"race\",\"body_mass_index_value\",\"abo_blood_group_system\",\"medical_history\",\"cause_of_death\",\"death_event\",\"mechanism_of_injury\"]\n",
+        "row_metadata = {\n",
+        "    ls[\"hubmap_id\"]: {\n",
+        "        \"title\": ls.get(\"title\"),\n",
+        "        \"assay_display_name\": ls.get(\"assay_display_name\"),\n",
+        "        \"anatomy\": first(ls.get(\"anatomy_2\")) or first(ls.get(\"anatomy_1\")),\n",
+        "        **{k: first(dmm.get(k)) for k in dmm_keys},\n",
+        "    } for l in hits if (ls := l.get(\"_source\", {})).get(\"hubmap_id\") for dmm in [ls.get(\"donor\", {}).get(\"mapped_metadata\", {})]\n",
+        "}"
       ]
     },
     {
@@ -73,7 +94,9 @@
         "\n",
         "anndata_locations_list = [f\"./datasets/{uuid}/secondary_analysis.h5ad\" for uuid in uuids]\n",
         "\n",
-        "scd = scellop.load_data_multiple(anndata_locations_list, hubmap_ids, \"predicted_CLID\")\n",
+        "scd = scellop.load_data_multiple(anndata_locations_list, hubmap_ids, \"predicted_CLID\", c_cols_meta=[\"predicted_label\"])\n",
+        "scd.row_metadata.update(row_metadata)\n",
+        "\n",
         "scellop.ScellopWidget(data=scd)"
       ]
     },


### PR DESCRIPTION
Changes
- The `ScellopWidget` takes either a `df` or `data`, but anything returned from the loader functions is of type `ScellopData`, which should be passed into `data` rather than `df`
- Added some specific hubmap metadata example so people can explore the sorts and filters as well